### PR TITLE
Fetch ldc pagination

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$


### PR DESCRIPTION
Adds the argument `take` to `fetch_ldc()` so that records can be retrieved in multiple queries made of smaller subsets of the total records available to avoid response failures or (in the worst case scenario) crashing the API.